### PR TITLE
Add linter setup using ruff (closes #6)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,8 @@
+name: Ruff linter
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "C",  # flake8-comprehensions
+    "B",  # flake8-bugbear
+    "PL", # pylint
+]
+line-length = 120


### PR DESCRIPTION
This PR introduces a linter setup using the tool [ruff](https://docs.astral.sh/ruff/).

This includes

- A ruff configuration on the project level as `ruff.toml`
- A GitHub workflow for continuous checks 