### PR TITLE
Replace ruff linter action with official one

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
   black:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The previous used linter by chartboost is not maintained anymore, thus switching the the official one by astral-sh.